### PR TITLE
MBS-6388: Distribute users without rating

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -101,6 +101,15 @@ $capabilities = array(
             'manager' => CAP_ALLOW
         )
     ),
+    'mod/ratingallocate:distribute_unallocated' => array(
+        'contextlevel' => CONTEXT_MODULE,
+        'riskbitmask' => RISK_PERSONAL,
+        'captype' => 'write',
+        'archetypes' => array(
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW
+        )
+    ),
 );
 
 

--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -81,6 +81,17 @@ Only users who rated at least one choice and who are not allocated yet are liste
 $string['allocation_manual_explain_all'] = 'Select a choice to be assigned to a user.';
 $string['distribution_algorithm'] = 'Distribution Algorithm';
 $string['distribution_saved'] = 'Distribution saved (in {$a}s).';
+$string['distributeequally'] = 'Distribute unallocated users equally';
+$string['distributefill'] = 'Distribute unallocated users by filling up';
+$string['distribution_description_help'] = 'You can choose between two different algorithms to distribute currently unallocated users.<br/>'
+    . '<i>Distribute equally:</i> Users are being distributed equally across the choices regarding the maximum of each choice.<br/>'
+    . '<i>Fill up choices:</i> Every choice is being filled up with users first before filling up the next choice. Choices with '
+    . 'least places left are filled up first.<br/><br/>'
+    . 'Group restrictions will be respected.';
+$string['distribute_unallocated_fill_confirm'] = 'All currently unallocated users will be distributed to the choices. '
+    . 'Each choice will be filled up to its maximum before assigning users to the next choice.';
+$string['distribute_unallocated_equally_confirm'] = 'All currently unallocated users will be distributed to the choices. '
+    . 'The choices will be filled up equally, so all of them have about the same amount of places left.';
 $string['no_user_to_allocate'] = 'There is no user you could allocate';
 $string['ratings_table'] = 'Ratings and Allocations';
 $string['ratings_table_sum_allocations'] = 'Number of allocations / Maximum';
@@ -102,6 +113,7 @@ $string['algorithm_now_scheduled_for_cron'] = 'The allocation algorithm run has 
 $string['start_distribution'] = 'Run Allocation Algorithm';
 $string['confirm_start_distribution'] = 'Running the algorithm will delete all existing allocations, if any. Are you sure to continue?';
 $string['unassigned_users'] = 'Unassigned Users';
+$string['unassigned_users_assigned'] = 'Unassigned users have been assigned as good as possible.';
 $string['invalid_dates'] = 'Dates are invalid. Starting date must be before ending date.';
 $string['invalid_publishdate'] = 'Publication date is invalid. Publication date must be after the end of rating.';
 $string['rated'] = 'rated {$a}';

--- a/lang/en/ratingallocate.php
+++ b/lang/en/ratingallocate.php
@@ -38,6 +38,7 @@ $string['pluginname'] = 'Fair Allocation';
 $string['groupingname'] = 'Created from Fair Allocation "{$a}"';
 $string['ratingallocate:addinstance'] = 'Add new instance of Fair Allocation';
 $string['ratingallocate:view'] = 'View instances of Fair Allocation';
+$string['ratingallocate:distribute_unallocated'] = 'Ability to distribute unallocated users automatically';
 $string['ratingallocate:give_rating'] = 'Create or edit choice';
 $string['ratingallocate:start_distribution'] = 'Start allocation of users to choices';
 $string['ratingallocate:export_ratings'] = 'Ability to export the user ratings';
@@ -83,6 +84,7 @@ $string['distribution_algorithm'] = 'Distribution Algorithm';
 $string['distribution_saved'] = 'Distribution saved (in {$a}s).';
 $string['distributeequally'] = 'Distribute unallocated users equally';
 $string['distributefill'] = 'Distribute unallocated users by filling up';
+$string['distribution_description'] = 'Distribution of unallocated users';
 $string['distribution_description_help'] = 'You can choose between two different algorithms to distribute currently unallocated users.<br/>'
     . '<i>Distribute equally:</i> Users are being distributed equally across the choices regarding the maximum of each choice.<br/>'
     . '<i>Fill up choices:</i> Every choice is being filled up with users first before filling up the next choice. Choices with '

--- a/locallib.php
+++ b/locallib.php
@@ -624,20 +624,6 @@ class ratingallocate {
     }
 
     public function distribute_users_without_choice(string $distributionalgorithm): void {
-        /*print_r($this->get_ratings_for_rateable_choices());
-        print_r("<br>BLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA<br>");
-        print_r($this->get_rateable_choices());
-        print_r("<br>BLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA<br>");
-        print_r($this->get_allocations());
-        print_r("<br>BLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA<br>");*/
-        //print_r($this->get_raters_in_course());
-        //print_r("<br>BLAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA<br>");
-        $placesleft = [];
-
-        //TODO Test code, wieder entfernen:
-        /*$this->clear_all_allocations();
-        $this->add_allocation(4,3);
-        $this->add_allocation(8, 4);*/
 
         foreach ($this->get_rateable_choices() as $choice) {
             $placesleft[$choice->id] = $choice->maxsize -

--- a/locallib.php
+++ b/locallib.php
@@ -625,6 +625,7 @@ class ratingallocate {
 
     public function distribute_users_without_choice(string $distributionalgorithm): void {
 
+        $placesleft = [];
         foreach ($this->get_rateable_choices() as $choice) {
             $placesleft[$choice->id] = $choice->maxsize -
                 count(array_filter($this->get_allocations(), fn($allocation) => $allocation->choiceid === $choice->id));
@@ -966,7 +967,8 @@ class ratingallocate {
                 $output .= $this->process_action_manual_allocation();
                 break;
 
-            case ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY || ACTION_DISTRIBUTE_UNALLOCATED_FILL:
+            case ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY:
+            case ACTION_DISTRIBUTE_UNALLOCATED_FILL:
                 $this->distribute_users_without_choice($action);
                 redirect(new moodle_url('/mod/ratingallocate/view.php',
                             ['id' => $this->coursemodule->id, 'action' => ACTION_NONE]),

--- a/renderer.php
+++ b/renderer.php
@@ -331,6 +331,26 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
             'action' => ACTION_MANUAL_ALLOCATION)), get_string('manual_allocation_form', ratingallocate_MOD_NAME), 'get',
             array('disabled' => !$ratingover));
 
+
+        $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY));
+
+        $button = new single_button($distributeunallocatedurl, get_string('distributeequally', ratingallocate_MOD_NAME), 'get');
+        // Enable only if the instance is ready and the algorithm may run manually
+        $button->disabled = !($ratingover);
+        $button->add_action(new confirm_action(get_string('distribute_unallocated_equally_confirm', ratingallocate_MOD_NAME)));
+
+        $output .= $this->render($button);
+
+        $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_FILL));
+        $button = new single_button($distributeunallocatedurl, get_string('distributefill', ratingallocate_MOD_NAME), 'get');
+        // Enable only if the instance is ready and the algorithm may run manually
+        $button->disabled = !($ratingover);
+        $button->add_action(new confirm_action(get_string('distribute_unallocated_fill_confirm', ratingallocate_MOD_NAME)));
+
+        $output .= $this->render($button);
+
+        $output .= $this->help_icon('distribution_description', ratingallocate_MOD_NAME);
+
         $output .= $this->box_end();
         return $output;
     }

--- a/renderer.php
+++ b/renderer.php
@@ -332,24 +332,32 @@ class mod_ratingallocate_renderer extends plugin_renderer_base {
             array('disabled' => !$ratingover));
 
 
-        $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY));
+        if (has_capability('mod/ratingallocate:distribute_unallocated', context_module::instance($coursemoduleid))) {
+            $output .= html_writer::start_div('ratingallocate_distribute_unallocated');
 
-        $button = new single_button($distributeunallocatedurl, get_string('distributeequally', ratingallocate_MOD_NAME), 'get');
-        // Enable only if the instance is ready and the algorithm may run manually
-        $button->disabled = !($ratingover);
-        $button->add_action(new confirm_action(get_string('distribute_unallocated_equally_confirm', ratingallocate_MOD_NAME)));
+            $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY));
 
-        $output .= $this->render($button);
+            $button = new single_button($distributeunallocatedurl,
+                get_string('distributeequally', ratingallocate_MOD_NAME), 'get');
+            // Enable only if the instance is ready and the algorithm may run manually
+            $button->disabled = !($ratingover);
+            $button->add_action(new confirm_action(
+                get_string('distribute_unallocated_equally_confirm',ratingallocate_MOD_NAME)));
 
-        $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_FILL));
-        $button = new single_button($distributeunallocatedurl, get_string('distributefill', ratingallocate_MOD_NAME), 'get');
-        // Enable only if the instance is ready and the algorithm may run manually
-        $button->disabled = !($ratingover);
-        $button->add_action(new confirm_action(get_string('distribute_unallocated_fill_confirm', ratingallocate_MOD_NAME)));
+            $output .= $this->render($button);
 
-        $output .= $this->render($button);
+            $distributeunallocatedurl = new moodle_url($PAGE->url, array('action' => ACTION_DISTRIBUTE_UNALLOCATED_FILL));
+            $button = new single_button($distributeunallocatedurl,
+                get_string('distributefill', ratingallocate_MOD_NAME), 'get');
+            // Enable only if the instance is ready and the algorithm may run manually
+            $button->disabled = !($ratingover);
+            $button->add_action(new confirm_action(
+                get_string('distribute_unallocated_fill_confirm', ratingallocate_MOD_NAME)));
 
-        $output .= $this->help_icon('distribution_description', ratingallocate_MOD_NAME);
+            $output .= $this->render($button);
+            $output .= $this->help_icon('distribution_description', ratingallocate_MOD_NAME);
+            $output .= html_writer::end_div();
+        }
 
         $output .= $this->box_end();
         return $output;

--- a/styles.css
+++ b/styles.css
@@ -57,3 +57,7 @@
 .path-mod-ratingallocate .mod-ratingallocate-choice-maxno {
     text-align: right;
 }
+
+.ratingallocate_distribute_unallocated {
+    margin: 1em 1em 0 0;
+}

--- a/tests/mod_ratingallocate_allocate_unrated_test.php
+++ b/tests/mod_ratingallocate_allocate_unrated_test.php
@@ -1,0 +1,379 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+defined('MOODLE_INTERNAL') || die();
+require_once(__DIR__ . '/generator/lib.php');
+require_once(__DIR__ . '/../locallib.php');
+
+/**
+ * Tests distribution of users who did not rate.
+ *
+ * @package    mod_ratingallocate
+ * @category   test
+ * @group      mod_ratingallocate
+ * @copyright  2022 ISB Bayern
+ * @author     Philipp Memmel
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class mod_ratingallocate_allocate_unrated_test extends advanced_testcase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+
+        $generator = $this->getDataGenerator();
+
+        $course = $generator->create_course();
+        $this->course = $course;
+        $this->teacher = mod_ratingallocate_generator::create_user_and_enrol($this, $course, true);
+        $this->setUser($this->teacher);
+
+        // Make test groups and enrol students.
+        $this->green = $generator->create_group(['name' => 'Green Group', 'courseid' => $course->id]);
+        $this->blue = $generator->create_group(['name' => 'Blue Group', 'courseid' => $course->id]);
+        $this->red = $generator->create_group(['name' => 'Red Group', 'courseid' => $course->id]);
+
+        // We need a few more students to see if distribution is ok.
+        for ($i = 0; $i < 10; $i++) {
+            $this->studentsgreen[] = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+            groups_add_member($this->green, $this->studentsgreen[$i]);
+            $this->studentsblue[] = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+            groups_add_member($this->blue, $this->studentsblue[$i]);
+            $this->studentsred[] = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+            groups_add_member($this->red, $this->studentsred[$i]);
+            $this->studentsnogroup[] = mod_ratingallocate_generator::create_user_and_enrol($this, $course);
+        }
+    }
+
+    private function get_choice_id_by_title(string $title): int {
+        return $this->get_choice_by_title($title)->id;
+    }
+
+    private function get_choice_by_title(string $title): stdClass {
+        return array_values(array_filter($this->ratingallocate->get_rateable_choices(),
+            fn($choice) => $choice->title === $title))[0];
+    }
+
+    private function get_allocation_count_for_choice(string $title): int {
+        $choiceswithallocationcount = $this->ratingallocate->get_choices_with_allocationcount();
+        $choiceswithallocationcount = array_filter($choiceswithallocationcount, fn($choice) => $choice->title === $title);
+        return (int) array_values($choiceswithallocationcount)[0]->usercount;
+    }
+
+    private function allocate_random_users(): void {
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('B'), $this->studentsgreen[3]->id);
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('B'), $this->studentsred[7]->id);
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('C'), $this->studentsblue[9]->id);
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('D'), $this->studentsnogroup[2]->id);
+    }
+
+    private function assert_allocation_of_random_users(): void {
+        $this->assertEquals($this->get_choice_id_by_title('B'),
+            array_values($this->ratingallocate->get_allocations_for_user($this->studentsgreen[3]->id))[0]->choiceid);
+        $this->assertEquals($this->get_choice_id_by_title('B'),
+            array_values($this->ratingallocate->get_allocations_for_user($this->studentsred[7]->id))[0]->choiceid);
+        $this->assertEquals($this->get_choice_id_by_title('C'),
+            array_values($this->ratingallocate->get_allocations_for_user($this->studentsblue[9]->id))[0]->choiceid);
+        $this->assertEquals($this->get_choice_id_by_title('D'),
+            array_values($this->ratingallocate->get_allocations_for_user($this->studentsnogroup[2]->id))[0]->choiceid);
+    }
+
+    /**
+     * Test distribution without groups.
+     *
+     * @return void
+     * @throws coding_exception
+     */
+    public function test_distribution_without_groups(): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'maxsize' => 8,
+                'active' => true,
+                'usegroups' => false
+            ];
+            $choices[] = $choice;
+        }
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+
+        // Tests
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('A'), $this->studentsnogroup[0]->id);
+        $this->ratingallocate->add_allocation($this->get_choice_id_by_title('A'), $this->studentsnogroup[1]->id);
+        $this->assertEquals(2, $this->get_allocation_count_for_choice('A'));
+        $this->ratingallocate->distribute_users_without_choice(ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY);
+        foreach (range('A', 'E') as $groupname) {
+            $this->assertEquals(8, $this->get_allocation_count_for_choice($groupname));
+        }
+
+        // Reset allocations.
+        $this->ratingallocate->clear_all_allocations();
+
+        // We now test what happens with more users than places in the choices.
+        for ($i = 0; $i < 10; $i++) {
+            mod_ratingallocate_generator::create_user_and_enrol($this, $this->course);
+        }
+        $this->assertEquals(51, count(enrol_get_course_users($this->course->id)));
+        $this->ratingallocate->distribute_users_without_choice(ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY);
+        foreach (range('A', 'E') as $choicetitle) {
+            // We still should have the maximum amount of students assigned to the choices.
+            $this->assertEquals(8, $this->get_allocation_count_for_choice($choicetitle));
+        }
+    }
+
+    /**
+     * Test the distribution of users to choices with group restrictions, using both algorithms.
+     *
+     * @return void
+     */
+    public function test_allocation_with_groups_common_features(): void {
+        $this->test_allocation_with_groups_with_algorithm(ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY);
+        $this->test_allocation_with_groups_with_algorithm(ACTION_DISTRIBUTE_UNALLOCATED_FILL);
+    }
+
+    /**
+     * This is a proper test function. It's private, because it's called with both types of algorithms by
+     *  test_allocation_with_groups function.
+     *
+     * @param string $algorithm the algorithm to use for running this test function
+     * @return void
+     */
+    private function test_allocation_with_groups_with_algorithm(string $algorithm): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'maxsize' => 8,
+                'active' => true,
+            ];
+
+            if ($letter === 'D' || $letter === 'E') {
+                $choice['usegroups'] = true;
+            } else {
+                $choice['usegroups'] = false;
+            }
+            $choices[] = $choice;
+        }
+
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+        // Assign blue and green group to choice E. So E is only available to green and blue students.
+        $this->ratingallocate->update_choice_groups($this->get_choice_id_by_title('D'), [$this->blue->id, $this->green->id]);
+        // We don't assign a group to E, so E should not be available to any student.
+        $this->ratingallocate->distribute_users_without_choice($algorithm);
+        foreach (range('A', 'D') as $choicetitle) {
+            $this->assertEquals(8, $this->get_allocation_count_for_choice($choicetitle));
+        }
+        $this->assertEquals(0, $this->get_allocation_count_for_choice('E'));
+
+        // Let's check other method.
+        $this->ratingallocate->clear_all_allocations();
+        $this->ratingallocate->distribute_users_without_choice($algorithm);
+        // We have 40 users for only 4 options with 8 students max each. So everything should be filled up except E, because E
+        // cannot be assigned, because E has no groups.
+        foreach (range('A', 'D') as $groupname) {
+            $this->assertEquals(8, $this->get_allocation_count_for_choice($groupname));
+        }
+
+        // We now assign a group to E, so all users should be distributed, because we got 40 places in total for 40 students.
+        $this->ratingallocate->clear_all_allocations();
+        $this->ratingallocate->update_choice_groups($this->get_choice_id_by_title('E'), [$this->red->id]);
+        $this->ratingallocate->distribute_users_without_choice($algorithm);
+        foreach (range('A', 'E') as $groupname) {
+            $this->assertEquals(8, $this->get_allocation_count_for_choice($groupname));
+        }
+        // Let's make sure students from specific groups only are assigned to the choices with the group restrictions.
+        // Choice E only allowed students from group red.
+        $allocationsforfifthchoice = array_filter($this->ratingallocate->get_allocations(),
+            fn($allocation) => $allocation->choiceid === $this->get_choice_id_by_title('E'));
+        foreach ($allocationsforfifthchoice as $allocation) {
+            $this->assertTrue(in_array($allocation->userid, array_map(fn($user) => $user->id, $this->studentsred)));
+        }
+        // Choice D only allowed students from groups blue or green.
+        $allocationsforfourthchoice = array_filter($this->ratingallocate->get_allocations(),
+            fn($allocation) => $allocation->choiceid === $this->get_choice_id_by_title('D'));
+        foreach ($allocationsforfourthchoice as $allocation) {
+            $this->assertTrue(in_array($allocation->userid,
+                array_map(fn($user) => $user->id, array_merge($this->studentsblue, $this->studentsgreen))));
+        }
+    }
+
+    /**
+     * Test the distribution of users to choices with group restrictions, using both algorithms.
+     *
+     * @return void
+     */
+    public function test_allocation_without_groups_common_features(): void {
+        $this->test_allocation_without_groups_with_algorithm(ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY);
+        $this->test_allocation_without_groups_with_algorithm(ACTION_DISTRIBUTE_UNALLOCATED_FILL);
+    }
+
+    private function test_allocation_without_groups_with_algorithm(string $algorithm): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'maxsize' => 8,
+                'active' => true,
+            ];
+            $choices[] = $choice;
+        }
+
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+
+        // We now test what happens with more users than places in the choices.
+        $newusers = [];
+        for ($i = 0; $i < 10; $i++) {
+            $newusers[] = mod_ratingallocate_generator::create_user_and_enrol($this, $this->course);
+        }
+        $this->assertEquals(51, count(enrol_get_course_users($this->course->id)));
+        $this->ratingallocate->distribute_users_without_choice($algorithm);
+        foreach (range('A', 'E') as $choicetitle) {
+            // We still should have the maximum amount of students assigned to the choices.
+            $this->assertEquals(8, $this->get_allocation_count_for_choice($choicetitle));
+        }
+        $this->ratingallocate->clear_all_allocations();
+        foreach($newusers as $user) {
+            delete_user($user);
+
+        }
+    }
+
+    /**
+     * Test the EQUALLY algorithm without groups. The algorithm tries to distribute the users so that each choice has equal places
+     * left or at most there is a difference of one user for the left places per choice.
+     *
+     * @return void
+     */
+    public function test_distribute_equally_without_groups(): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        $i = 14;
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'active' => true,
+                'usegroups' => false,
+                // We choose 14, 12, 10, 8 and 6 maxsize values for the groups A, B, C, D, E.
+                // This means 50 places for 40 users in the course.
+                'maxsize' => $i
+            ];
+
+            $choices[] = $choice;
+            $i -= 2;
+        }
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+
+        // Randomly manually allocate some students to some choices to see if the algorithm can deal with that.
+        $this->allocate_random_users();
+
+        $this->ratingallocate->distribute_users_without_choice(ACTION_DISTRIBUTE_UNALLOCATED_EQUALLY);
+        $i = 14;
+        foreach ($letters as $groupname) {
+            // All choices should be equally filled up. We have 50 places and 40 users, so every choice should have 2 places left
+            // after distribution.
+            $this->assertEquals($i - 2, $this->get_allocation_count_for_choice($groupname));
+            $i -= 2;
+        }
+
+        // Assert the allocations already existing before have not changed.
+        $this->assert_allocation_of_random_users();
+    }
+
+    /**
+     * Test the FILL algorithm without groups. This algorithm just fills up every choice. Choices with least places left are
+     * being filled up first.
+     *
+     * @return void
+     */
+    public function test_distribute_fill_without_groups(): void {
+        $choices = [];
+
+        $letters = range('A', 'E');
+        $i = 14;
+        foreach ($letters as $letter) {
+            $choice = [
+                'title' => "$letter",
+                'explanation' => "Explain Choice $letter",
+                'active' => true,
+                'usegroups' => false,
+                // We choose 14, 12, 10, 8 and 6 maxsize values for the groups A, B, C, D, E.
+                // This means 50 places for 40 users in the course.
+                'maxsize' => $i
+            ];
+
+            $choices[] = $choice;
+            $i -= 2;
+        }
+        $mod = mod_ratingallocate_generator::create_instance_with_choices($this,
+            ['course' => $this->course,
+                'strategyopt' => ['countoptions' => 3],
+                'strategy' => 'strategy_order'],
+            $choices);
+        $this->ratingallocate = mod_ratingallocate_generator::get_ratingallocate_for_user($this, $mod, $this->teacher);
+
+        // Randomly manually allocate some students to some choices to see if the algorithm can deal with that.
+        $this->allocate_random_users();
+
+        $this->ratingallocate->distribute_users_without_choice(ACTION_DISTRIBUTE_UNALLOCATED_FILL);
+
+        $i = 14;
+        foreach ($letters as $groupname) {
+            // A choice should be filled up completely before going for the next one by this algorithm. Choices with least places
+            // left should be first filled up. This would mean we fill 'E', then 'D', then 'C', then 'B' and 4 users should be left
+            // for 'A'.
+            if ($groupname == 'A') {
+                $this->assertEquals(4, $this->get_allocation_count_for_choice($groupname));
+            } else {
+                $this->assertEquals($i, $this->get_allocation_count_for_choice($groupname));
+            }
+            $i -= 2;
+        }
+
+        // Assert the allocations already existing before have not changed.
+        $this->assert_allocation_of_random_users();
+    }
+}

--- a/tests/mod_ratingallocate_choice_importer_test.php
+++ b/tests/mod_ratingallocate_choice_importer_test.php
@@ -130,9 +130,9 @@ class mod_ratingallocate_choice_importer_testcase extends advanced_testcase {
 
         $contents = $this->get_choice_lines(false);
         // Some new groups of groups, some with questionable whitespace and empty values in group names.
-        $contents[] = 'New Test Choice 6,Explain New Choice 6, 100, 1," Blue Group, Green Group"';
-        $contents[] = 'New Test Choice 7,Explain New Choice 7, 100, 1,"Blue Group,Green Group,Red Group "';
-        $contents[] = 'New Test Choice 8,Explain New Choice 8, 100, 1,"Green Group,Red Group,, "';
+        $contents[] = 'New Test Choice 6,Explain New Choice 6, 100, 1," Blue Group; Green Group"';
+        $contents[] = 'New Test Choice 7,Explain New Choice 7, 100, 1,"Blue Group;Green Group;Red Group "';
+        $contents[] = 'New Test Choice 8,Explain New Choice 8, 100, 1,"Green Group;Red Group;; "';
         $csv = join("\n", $contents) . "\n";
         $importstatus = $choiceimporter->import($csv);
         $this->assertEquals($importstatus->status, \mod_ratingallocate\choice_importer::IMPORT_STATUS_OK);

--- a/version.php
+++ b/version.php
@@ -26,7 +26,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022042801;        // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2022052600;        // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2017111300;        // Requires this Moodle version
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = 'v3.10-r1';


### PR DESCRIPTION
Users who haven't voted are not considered by the distribution algorithm. So there has to be the ability for the teacher to distribute these users as well after the algorithm has run.

This PR adds such functionality. It offers two heuristics to the teacher to do that:

- Distribute equally: Users are being distributed equally across the choices regarding the maximum of each choice. This means every choice has about the same amount of choices left after distribution.
- Fill up choices: Every choice is being filled up with users first before filling up the next choice. Choices with least places left are filled up first.

Both heuristics will respect the restrictions of choices to specific groups.